### PR TITLE
Test functionality of 'Honeypot' module on GovCMS site

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
+  "baseUrl": "http://govcms-testing.docker.amazee.io/",
   "env": {
     "drupalSuperUser": "admin",
     "drupalSuperUserPassword": "password"

--- a/cypress/integration/honeypot/honeypot.spec.js
+++ b/cypress/integration/honeypot/honeypot.spec.js
@@ -1,50 +1,93 @@
 describe("verify the functionality of Honeypot module", function() {
-  it("Log in and checks for Honeypot status", function() {
-    cy.visit("https://govcms-testing.govcms.gov.au/user/login");
+  beforeEach(()=>{
+//beforeEach will run 'login' cusomised command everytime it runs 'it' function
+//custom 'logn' command can be found in cypress/support/commands.js
+    cy.login()
+  })
 
-    cy.get ("#edit-name")
-      .type ("admin.honeypot")
-
-    cy.get ("#edit-pass")
-      .type ("honeypot")
-
-    cy.get("#edit-submit").click()
+  it("find module", function() {
 
     cy.contains("Extend").click()
 
-    cy.get("#edit-text")
-      .type("honeypot")
+//tick the checkbox of Honeypot module
+    cy.get("form")
+      .find("#edit-modules-honeypot-enable")
+      .check({force:true})
+//save the change
+    cy.get("#edit-submit")
+      .click()
 
-    cy.get("#edit-modules-honeypot-enable")
-      .should("have", "#edit-modules-honeypot-enable")
-
-
+//    cy.contains("Module Honeypot has been enabled.")
   });
 
-  it("", function() {
-    cy.visit("https://govcms-testing.govcms.gov.au/user/login");
+  it("configure Honypot configuration", function() {
 
-    cy.get ("#edit-name")
-      .type ("admin.honeypot")
-
-    cy.get ("#edit-pass")
-      .clear()
-      .type ("honeypot",{forece : true})
-
-    cy.get("#edit-submit").click()
     cy.visit("https://govcms-testing.govcms.gov.au/admin/config/content/honeypot")
 
-    cy.get("#edit-element-name")
-      .type("myaddress")
-
-    cy.get("#edit-log").check()
+    cy.get("#edit-log").check({force:true})
 
     cy.get("#edit-element-name")
+      .clear({force:true})
       .type("myaddress")
 
-    cy.get("#edit-form-settings-node-govcms-standard-page-form").check()
+    cy.get("#edit-form-settings-user-pass").check({force:true})
+    cy.contains("Save configuration").click({force:true})
 
-
+    cy.contains("The configuration options have been saved.")
   })
+
+    it("enable Webform module", function() {
+
+      cy.contains("Extend").click()
+
+      //tick the checkbox of Consumers module
+          cy.get("form")
+            .find("#edit-modules-webform-enable")
+            .check({force:true})
+      //save the change
+          cy.get("#edit-submit")
+            .click()
+    });
+
+it("Correct password reset form", function() {
+  cy.visit("https://govcms-testing.govcms.gov.au/user/logout")
+
+  cy.visit("https://govcms-testing.govcms.gov.au/user/password")
+//wait 5 seconds otherwise considered as a bot
+//I have commented out the wait command as it is considered as problem when committing this script to github
+  //cy.wait(5000)
+  cy.get("#edit-name")
+  .type("honeypot.test@email.a")
+
+  cy.get("#edit-submit")
+  .click()
+
+  cy.contains("Further instructions have been sent to your e-mail address.")
+})
+
+  it("Tiggers honeypot", function() {
+    cy.visit("https://govcms-testing.govcms.gov.au/user/logout")
+
+    cy.visit("https://govcms-testing.govcms.gov.au/user/password")
+//wait 5 seconds otherwise considered as a bot
+//I have commented out the wait command as it is considered as problem when committing this script to github
+    //cy.wait(5000)
+
+    cy.get("#edit-name")
+    .type("honeypot.test@email.a")
+
+    cy.get("#edit-myaddress")
+    .type("blockme", {force:true})
+
+    cy.get("#edit-submit")
+    .click()
+
+    cy.contains("There was a problem with your form submission.")
+  })
+
+// there are two cases that triggers honeypot.
+// 1 - if any entry is found in the element named 'myaddress'
+// 2 - if putting in a normal entry in less then 5 seconds.
+// it should be sufficent to check the error message "There was a problem with your form submission."/ or success message "Further instructions have been sent to your e-mail address."
 
 });

--- a/cypress/integration/honeypot/honeypot.spec.js
+++ b/cypress/integration/honeypot/honeypot.spec.js
@@ -1,0 +1,50 @@
+describe("verify the functionality of Honeypot module", function() {
+  it("Log in and checks for Honeypot status", function() {
+    cy.visit("https://govcms-testing.govcms.gov.au/user/login");
+
+    cy.get ("#edit-name")
+      .type ("admin.honeypot")
+
+    cy.get ("#edit-pass")
+      .type ("honeypot")
+
+    cy.get("#edit-submit").click()
+
+    cy.contains("Extend").click()
+
+    cy.get("#edit-text")
+      .type("honeypot")
+
+    cy.get("#edit-modules-honeypot-enable")
+      .should("have", "#edit-modules-honeypot-enable")
+
+
+  });
+
+  it("", function() {
+    cy.visit("https://govcms-testing.govcms.gov.au/user/login");
+
+    cy.get ("#edit-name")
+      .type ("admin.honeypot")
+
+    cy.get ("#edit-pass")
+      .clear()
+      .type ("honeypot",{forece : true})
+
+    cy.get("#edit-submit").click()
+    cy.visit("https://govcms-testing.govcms.gov.au/admin/config/content/honeypot")
+
+    cy.get("#edit-element-name")
+      .type("myaddress")
+
+    cy.get("#edit-log").check()
+
+    cy.get("#edit-element-name")
+      .type("myaddress")
+
+    cy.get("#edit-form-settings-node-govcms-standard-page-form").check()
+
+
+  })
+
+});

--- a/cypress/integration/honeypot/honeypot.spec.js
+++ b/cypress/integration/honeypot/honeypot.spec.js
@@ -2,27 +2,64 @@ describe("verify the functionality of Honeypot module", function() {
   beforeEach(()=>{
 //beforeEach will run 'login' cusomised command everytime it runs 'it' function
 //custom 'logn' command can be found in cypress/support/commands.js
-    cy.login()
+//otherwise add below codes from line 6 - 15 to cypress/support/commands.js
+// Cypress.Commands.add("login", () => {
+//   cy.visit("/user/login");
+//   cy.get ("#edit-name")
+//     .type ("admin")
+//   cy.get ("#edit-pass")
+//     .type ("password")
+//     //save the change
+//   cy.get("#edit-submit")
+//     .click()
+// })
+//insert base url in cypress.json file example - {  "baseUrl": "http://govcms-testing.docker.amazee.io/",}
+cy.login()
   })
 
-  it("find module", function() {
-
-    cy.contains("Extend").click()
-
-//tick the checkbox of Honeypot module
-    cy.get("form")
-      .find("#edit-modules-honeypot-enable")
-      .check({force:true})
-//save the change
-    cy.get("#edit-submit")
-      .click()
-
+var honeypot = 0;
+var dblog = 0;
+//enable module
+  it("enable modules", function() {
+    cy.visit("admin/modules")
+      cy.get('body input#edit-modules-honeypot-enable').then((body) => {
+        console.log(body.is('[disabled=disabled]')) //true means enabled, false means disabled, displays log in browser- inspect- console
+        if (body.is('[disabled=disabled]') == true)
+          {honeypot = 0;}
+        if (body.is('[disabled=disabled]') == false){
+          cy.get("form")
+            .find("#edit-modules-honeypot-enable")
+            .check({force:true})
+            //save the change
+          cy.get("#edit-submit")
+            .click()
+            //confirm the change
+          cy.get("#edit-submit")
+            .click()
+        honeypot = 1;
+}})
+        cy.get('body input#edit-modules-dblog-enable').then((body) => {
+          console.log(body.is('[disabled=disabled]')) //true means enabled, false means disabled, displays log in browser- inspect- console
+          if (body.is('[disabled=disabled]') == true)
+            {dblog = 0;}
+          if (body.is('[disabled=disabled]') == false){
+            cy.get("form")
+              .find("#edit-modules-dblog-enable")
+              .check({force:true})
+              //save the change
+            cy.get("#edit-submit")
+              .click()
+              //confirm the change
+            cy.get("#edit-submit")
+              .click()
+          dblog = 1;
+}})
 //    cy.contains("Module Honeypot has been enabled.")
   });
 
   it("configure Honypot configuration", function() {
 
-    cy.visit("https://govcms-testing.govcms.gov.au/admin/config/content/honeypot")
+    cy.visit("/admin/config/content/honeypot")
 
     cy.get("#edit-log").check({force:true})
 
@@ -36,42 +73,51 @@ describe("verify the functionality of Honeypot module", function() {
     cy.contains("The configuration options have been saved.")
   })
 
-    it("enable Webform module", function() {
+    // it("enable Webform module", function() {
+    //
+    //   cy.contains("Extend").click()
+    //
+    //   //tick the checkbox of Consumers module
+    //       cy.get("form")
+    //         .find("#edit-modules-webform-enable")
+    //         .check({force:true})
+    //   //save the change
+    //       cy.get("#edit-submit")
+    //         .click()
+    // });
 
-      cy.contains("Extend").click()
-
-      //tick the checkbox of Consumers module
-          cy.get("form")
-            .find("#edit-modules-webform-enable")
-            .check({force:true})
-      //save the change
-          cy.get("#edit-submit")
-            .click()
-    });
+it("Create a dummy user", function() {
+  cy.visit("/admin/people/create")
+  cy.get('#edit-mail').type("honeypot.test@email.a", {force:true})
+  cy.get('#edit-name').type("honeypot.test@email.a" , {force:true})
+  cy.get('#edit-pass-pass1').type("Password123" , {force:true})
+  cy.get('#edit-pass-pass2').type("Password123" , {force:true})
+  cy.get('#edit-submit').click({force:true})
+})
 
 it("Correct password reset form", function() {
-  cy.visit("https://govcms-testing.govcms.gov.au/user/logout")
+  cy.visit("/user/logout")
 
-  cy.visit("https://govcms-testing.govcms.gov.au/user/password")
+  cy.visit("/user/password")
 //wait 5 seconds otherwise considered as a bot
 //I have commented out the wait command as it is considered as problem when committing this script to github
   //cy.wait(5000)
   cy.get("#edit-name")
   .type("honeypot.test@email.a")
-
+  //cy.wait(5000)
   cy.get("#edit-submit")
   .click()
 
-  cy.contains("Further instructions have been sent to your e-mail address.")
+  cy.contains("Further instructions have been sent to your email address.")
 })
 
   it("Tiggers honeypot", function() {
-    cy.visit("https://govcms-testing.govcms.gov.au/user/logout")
+    cy.visit("/user/logout")
 
-    cy.visit("https://govcms-testing.govcms.gov.au/user/password")
+    cy.visit("/user/password")
 //wait 5 seconds otherwise considered as a bot
 //I have commented out the wait command as it is considered as problem when committing this script to github
-    //cy.wait(5000)
+    //cy.wait(8000)
 
     cy.get("#edit-name")
     .type("honeypot.test@email.a")
@@ -89,5 +135,40 @@ it("Correct password reset form", function() {
 // 1 - if any entry is found in the element named 'myaddress'
 // 2 - if putting in a normal entry in less then 5 seconds.
 // it should be sufficent to check the error message "There was a problem with your form submission."/ or success message "Further instructions have been sent to your e-mail address."
+it ("check logs", function() {
+  cy.visit("/admin/reports/dblog")
+  cy.get('.views-field-type').contains("honeypot")
+  cy.get('.views-field-message > a').contains("Blocked submission of user_pass due")
+})
 
+it ("Remove the dummy user", function() {
+  cy.visit("/admin/people")
+  cy.get(':nth-child(1) > .views-field-operations > .dropbutton-wrapper > .dropbutton-widget > .dropbutton > .edit > a').click({Force:true})
+  cy.get("#edit-delete").click({force:true})
+  cy.get('#edit-user-cancel-method-user-cancel-delete').click({force:true})
+  cy.get('#edit-submit').click({force:true})
+  //I have commented out the wait command as it is considered as problem when committing this script to github
+  //cy.wait(2000)
+})
+
+it("disable module if", function(){
+  cy.visit ("/admin/modules/uninstall")
+  cy.get('form').then((body) => {
+    console.log(dblog)
+    if (dblog = 0){
+      cy.visit("/admin/modules/uninstall")
+    }
+    if (dblog = 1) {
+      cy.get("form")
+        .find("#edit-uninstall-dblog")
+        .check({force:true})
+        //save the change
+      cy.get("#edit-submit")
+        .click()
+        //confirm the change
+      cy.get("#edit-submit")
+        .click()
+  }})
+//honeypot will be still enabled as it is default
+})
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -37,15 +37,18 @@ Cypress.Commands.add("drupalLogin", (user, password) => {
     });
 });
 
-// Drupal login
 Cypress.Commands.add("login", () => {
-  cy.visit("https://govcms-testing.govcms.gov.au/user/login");
+  cy.visit("/user/login");
   cy.get ("#edit-name")
-    .type ("")
+    .type ("admin")
   cy.get ("#edit-pass")
-    .type ("{enter}")
-
+    .type ("password")
+    //save the change
+  cy.get("#edit-submit")
+    .click()
 })
+// Drupal login
+
 
 
 // Drupal logout

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -37,6 +37,17 @@ Cypress.Commands.add("drupalLogin", (user, password) => {
     });
 });
 
+// Drupal login
+Cypress.Commands.add("login", () => {
+  cy.visit("https://govcms-testing.govcms.gov.au/user/login");
+  cy.get ("#edit-name")
+    .type ("")
+  cy.get ("#edit-pass")
+    .type ("{enter}")
+
+})
+
+
 // Drupal logout
 Cypress.Commands.add('drupalLogout', () => {
     return cy.request('/user/logout');


### PR DESCRIPTION

Steps | Description | Expected Result
-- | -- | --
1 | Search for 'honeypot' module in the filter list text field1.1 - Module should be enabled by default1.2 - If module is not enabled, enable it via clicking on module 'On' button | System should display module updated status.
2 | Go to configuration > content authoring > Honeypot configuration. Check 'Log blocked form submissions', Honeypot element name as 'myaddress', Enable the forms where you want honeypot to work. Save configuration | System should able to save the configuration
3 | Go the above form selected, fill the form and try to submit. It should show the message 'There was a problem with your form submission. Please wait for 'time defined in honeypot' and try again' | System should show the honeypot wait message
4 | You can also check the honeypot message in recent logs -> administration > reports > recent log messages | System should show honeypot message in the logs

